### PR TITLE
Update osx-setup-guide.md for config.yml move.

### DIFF
--- a/registry/recipes/osx-setup-guide.md
+++ b/registry/recipes/osx-setup-guide.md
@@ -52,7 +52,7 @@ If you want to understand, you should read [How to Write Go Code](https://golang
 Copy the registry configuration file in place:
 
     mkdir /Users/Shared/Registry
-    cp docs/recipes/osx/config.yml /Users/Shared/Registry/config.yml
+    cp docs/content/recipes/osx/config.yml /Users/Shared/Registry/config.yml
 
 ## Run the Docker Registry under launchd
 

--- a/registry/recipes/osx-setup-guide.md
+++ b/registry/recipes/osx-setup-guide.md
@@ -58,8 +58,8 @@ Copy the registry configuration file in place:
 
 Copy the Docker registry plist into place:
 
-    plutil -lint docs/recipes/osx/com.docker.registry.plist
-    cp docs/recipes/osx/com.docker.registry.plist ~/Library/LaunchAgents/
+    plutil -lint docs/content/recipes/osx/com.docker.registry.plist
+    cp docs/content/recipes/osx/com.docker.registry.plist ~/Library/LaunchAgents/
     chmod 644 ~/Library/LaunchAgents/com.docker.registry.plist
 
 Start the Docker registry:


### PR DESCRIPTION
`docs/recipes/os/config.yml` has moved to `docs/content/recipes/osx/config.yml. Make the update.

### Proposed changes

Updated documentation because a path was out of date.